### PR TITLE
Media queries2.0

### DIFF
--- a/src/Components/Fridge.js
+++ b/src/Components/Fridge.js
@@ -10,7 +10,7 @@ const Fridge = ({ userSelection, handleRemoveWord }) => {
   return (
     <div className='fridge'>
         <h2 >this is the fridge!</h2>
-        <ul>
+        <ul className='words'>
           {
             userSelectionArr.map((item) => {
                 return(

--- a/src/Components/SelectedWords.js
+++ b/src/Components/SelectedWords.js
@@ -23,7 +23,6 @@ const SelectedWords = ({item, handleRemoveWord}) => {
             left: poemWord.x,
             touchAction: 'none',
           }}
-          className='words'
           onDoubleClick={(e) => {handleRemoveWord(e.target.textContent); handleClick(e)}}
         >{item}</li>
     )

--- a/src/Components/WordBank.js
+++ b/src/Components/WordBank.js
@@ -15,10 +15,10 @@ const WordBank = ({ words, searchQuery }) => {
         'a', 'al', 'ance', 'are', 'ation', 'tion', 'an', 'and', 'sion', 'as', 'at', 'ery', 'ist', 'ity', 'ment', 'by', 'else', 'ness', 'for', 'from', 'th', 'if', 'in', 'ty', 'not', 'of', 'off', 'on', 'onto', 'or', 'out', 'able', 'ible', 'the', 'to', 'too', 'with', 'ary', 'had', 'has', 'have', 'he', 'her', 'hers', 'him', 'his', 'I', 'is', 'it', 'its', 'ious', 'may', 'me', 'ful', 'ic', 'my', 'ous',  'y', 'ical', 'ly', 'our', 'ours', 'ish', 'she', 'should', 'that', 'their', 'ed', 'en', 'er', 'these', 'they', 'this', 'ing', 'ton', 'ize', 'ise', 'ify', 'fy', 'we', 'what', 'where', 'which', 'who', 'whom', 'whose', 'why', 'will', 'you', 'your', 'yours'
     ]);
 
-    const { height, width } = useWindowDimensions();
+    const { width } = useWindowDimensions();
 
     useEffect(() => {
-        if (width > 750) {
+        if (width >= 750) {
             setShowWords(true);
             setShowHelperWords(true);
         }

--- a/src/Components/WordBank.js
+++ b/src/Components/WordBank.js
@@ -1,4 +1,5 @@
 import Fridge from "./Fridge";
+import useWindowDimensions from '../hooks/useWindowDimensions';
 import { useState, useEffect } from 'react';
 
 const WordBank = ({ words, searchQuery }) => {
@@ -13,6 +14,15 @@ const WordBank = ({ words, searchQuery }) => {
     const [helperWordBank, setHelperWordBank] = useState([
         'a', 'al', 'ance', 'are', 'ation', 'tion', 'an', 'and', 'sion', 'as', 'at', 'ery', 'ist', 'ity', 'ment', 'by', 'else', 'ness', 'for', 'from', 'th', 'if', 'in', 'ty', 'not', 'of', 'off', 'on', 'onto', 'or', 'out', 'able', 'ible', 'the', 'to', 'too', 'with', 'ary', 'had', 'has', 'have', 'he', 'her', 'hers', 'him', 'his', 'I', 'is', 'it', 'its', 'ious', 'may', 'me', 'ful', 'ic', 'my', 'ous',  'y', 'ical', 'ly', 'our', 'ours', 'ish', 'she', 'should', 'that', 'their', 'ed', 'en', 'er', 'these', 'they', 'this', 'ing', 'ton', 'ize', 'ise', 'ify', 'fy', 'we', 'what', 'where', 'which', 'who', 'whom', 'whose', 'why', 'will', 'you', 'your', 'yours'
     ]);
+
+    const { height, width } = useWindowDimensions();
+
+    useEffect(() => {
+        if (width > 750) {
+            setShowWords(true);
+            setShowHelperWords(true);
+        }
+    }, [])
 
     useEffect(() => {
         const newWordBankArray = [];
@@ -98,16 +108,16 @@ const WordBank = ({ words, searchQuery }) => {
     return (
         <section className="displayWords">
             <div className="wordBank">
-                <h2>Words associated with {searchQuery}:</h2>
+                    
                 <button onClick={() => setShowWords(!showWords)}>
+                    <h2>Words associated with {searchQuery}:</h2>
                     {
                     showWords 
                         ? <i className="fa-solid fa-chevron-up"></i> 
                         : <i className="fa-solid fa-chevron-down"></i>
                     }
-                </button>
+                </button> 
                 
-
                 {
                     showWords 
                         ? (
@@ -128,14 +138,15 @@ const WordBank = ({ words, searchQuery }) => {
                 }
                 
 
-                <h2>Connecting Words</h2>
                 <button onClick={() => setShowHelperWords(!showHelperWords)}>
+                    <h2>Connecting Words</h2>
                     {
                     showHelperWords 
                         ? <i className="fa-solid fa-chevron-up"></i> 
                         : <i className="fa-solid fa-chevron-down"></i>
                     }
                 </button>
+
                 {
                     showHelperWords
                         ? (

--- a/src/hooks/useWindowDimensions.js
+++ b/src/hooks/useWindowDimensions.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+const getWindowDimensions = () => {
+  const { innerWidth: width, innerHeight: height } = window;
+  
+  return {
+    width,
+    height
+  };
+}
+
+const useWindowDimensions = () => {
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+}
+
+export default useWindowDimensions;

--- a/src/partials/_typography.scss
+++ b/src/partials/_typography.scss
@@ -12,3 +12,8 @@ body {
 h1 {
     font-weight: bold;
 }
+
+h1, h2, h3, h4, p {
+    padding: 0;
+    margin: 0;
+}

--- a/src/partials/_wordBank.scss
+++ b/src/partials/_wordBank.scss
@@ -10,10 +10,20 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  button {
+    h2 {
+      font-size: 1.5rem;
+    }
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 20px;
+  }
   .associatedWords,
   .helperWordBank {
     border: 1px solid $lightGreen;
     border-radius: 1rem;
+    height: 400px;
+    overflow: scroll;
   }
 }
 


### PR DESCRIPTION
- added overflow:scroll to ul words containers 
- since wordBank is hidden by default, created a custom hook useWindowDimension.js to set wordBank to show by default on desktop version (i.e. > 750px). 